### PR TITLE
Continues to build on previous example

### DIFF
--- a/content/Optimizing-rebundling.md
+++ b/content/Optimizing-rebundling.md
@@ -9,20 +9,24 @@ var path = require('path');
 var node_modules = path.resolve(__dirname, 'node_modules');
 var pathToReact = path.resolve(node_modules, 'react/dist/react.min.js');
 
-var config = {
-  entry: path.resolve(__dirname, 'app/main.js'),
-  resolve: {
-    alias: {
-      'react': pathToReact
-    }
-  },
-  output: {
-    path: path.resolve(__dirname, 'build'),
-    filename: 'bundle.js'
-  },
-  module: {
-    noParse: [pathToReact]
-  }
+config = {
+    entry: ['webpack/hot/dev-server', path.resolve(__dirname, 'app/main.js')],
+    resolve: {
+	    alias: {
+	      'react': pathToReact
+	    }
+	},
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: 'bundle.js',
+    },
+    module: {
+    	loaders: [{
+    		test: /\.jsx?$/,
+    		loader: 'babel'
+    	}],
+    	noParse: [pathToReact]
+    }    
 };
 
 module.exports = config;

--- a/content/Structuring-configuration.md
+++ b/content/Structuring-configuration.md
@@ -33,8 +33,10 @@ So there really is not much difference in creating the dev and production versio
 
 ```javascript
 var path = require('path');
+var node_modules_dir = path.resolve(__dirname, 'node_modules');
+
 var config = {
-  entry: path.resolve(__dirname, 'app/main.js')
+  entry: path.resolve(__dirname, 'app/main.js'),
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js'


### PR DESCRIPTION
I copied and pasted the previous code and it didn't work. I think this makes sense to me. We still want to use the babel/loader and look for js or jsx files.