### PR TITLE
add a tip for module.noParse

### DIFF
--- a/content/Optimizing-development.md
+++ b/content/Optimizing-development.md
@@ -42,6 +42,9 @@ module.exports = config;
 ```
 Not all modules include a minified distributed version of the lib, but most do. Especially with large libraries like React JS you will get a significant improvement.
 
+#### Important!
+Not all modules support module.noParse, the files included by deps array should have no call to *require*, *define* or similar, or you will get an error when the app runs: **Uncaught ReferenceError: require is not defined**.
+
 ## Exposing React to the global scope
 You might be using distributed versions that requires React JS on the global scope. To fix that you can install the expose-loader by `npm install expose-loader --save-dev` and set up the following config, focusing on the *module* property:
 


### PR DESCRIPTION
Thanks for your great work.

according to https://webpack.github.io/docs/configuration.html#module-noparse

files in module.noParse should not have call to require or define. I tried with alt-with-addons.min.js (with call to require) and alt.min.js(do not have any call to require). 

Error raised when used alt-with-addons.min.js.

Uncaught ReferenceError: require is not defined.

It may be a good idea to show this to reduce confusion.