### PR TITLE
Update Loading-CSS.md

### DIFF
--- a/content/Loading-CSS.md
+++ b/content/Loading-CSS.md
@@ -19,7 +19,9 @@ var config = {
     filename: 'bundle.js'
   },
   module: {
-    loaders: [{
+    loaders: [
+      { test: /\.js$/, loader: 'babel-loader' },
+      {
       test: /\.jsx$/,
       loader: 'babel'
     }, {


### PR DESCRIPTION
I had to add this line in webpack.config.js

{ test: /\.js$/, loader: 'babel-loader' },

in the modules section.

When I was folloing the tutorial I had this error without this line in the webpack.config.js.

Thanks for the tutorial.