### PR TITLE
Added node_modules for automatic browser refresh

### DIFF
--- a/content/Automatic-browser-refresh.md
+++ b/content/Automatic-browser-refresh.md
@@ -31,6 +31,9 @@ module.exports = {
         path: path.resolve(__dirname, 'build'),
         filename: 'bundle.js',
     },
+    modulesDirectories: [
+      'node_modules'
+    ]
 };
 ```
 


### PR DESCRIPTION
This pull request fixes this errors:

**ERROR in multi main
Module not found: Error: Cannot resolve module 'webpack/hot/dev-server' in /path/to/project
 @ multi main**

**ERROR in multi main
Module not found: Error: Cannot resolve module 'webpack-dev-server/client' in /path/to/project
 @ multi main***