### PR TITLE
Updated docs: Babel6 changes

### DIFF
--- a/content/Configuring-react-js.md
+++ b/content/Configuring-react-js.md
@@ -80,7 +80,7 @@ module.exports = config;
 To configure the babel-loader to use the es2015 and react presets, we create a .babelrc file as shown below.
 
 *.babelrc*
-```jascript
+```javascript
 {
     "presets": [ "es2015", "react" ]
 }

--- a/content/Configuring-react-js.md
+++ b/content/Configuring-react-js.md
@@ -51,8 +51,9 @@ function main() {
 ## Converting JSX
 
 To use the JSX syntax you will need webpack to transform your JavaScript. This is the job of a loader. We'll use [Babel](https://babeljs.io/) as it's nice and has plenty of features.
+Below we install the babel-loader with two other presets, es2015 and react.
 
-`npm install babel-loader --save-dev`
+`npm install babel-loader babel-core babel-preset-es2015 babel-preset-react --save-dev`
 
 Now we have to configure webpack to use this loader.
 
@@ -69,6 +70,9 @@ var config = {
     loaders: [{
       test: /\.jsx?$/, // A regexp to test the require path. accepts either js or jsx
       loader: 'babel' // The module to load. "babel" is short for "babel-loader"
+      query: {
+          presets: [ 'es2015', 'react' ]
+      }
     }]
   }
 };

--- a/content/Configuring-react-js.md
+++ b/content/Configuring-react-js.md
@@ -70,14 +70,20 @@ var config = {
     loaders: [{
       test: /\.jsx?$/, // A regexp to test the require path. accepts either js or jsx
       loader: 'babel' // The module to load. "babel" is short for "babel-loader"
-      query: {
-          presets: [ 'es2015', 'react' ]
-      }
     }]
   }
 };
 
 module.exports = config;
+```
+
+To configure the babel-loader to use the es2015 and react presets, we create a .babelrc file as shown below.
+
+*.babelrc*
+```jascript
+{
+    "presets": [ "es2015", "react" ]
+}
 ```
 
 Webpack will test each path required in your code. In this project we are using ES6 module loader syntax, which means that the require path of `import MyComponent from './Component.jsx';` is `'./Component.jsx'`.


### PR DESCRIPTION
Per docs. "Pre-6.x, Babel enabled certain transformations by default. However, Babel 6.x does not ship with any transformations enabled"