### PR TITLE
Adding file-loader to npm command for inlining images

### DIFF
--- a/content/Inlining-images.md
+++ b/content/Inlining-images.md
@@ -1,7 +1,7 @@
 Until HTTP/2 is here you want to avoid setting up too many HTTP requests when your application is loading. Depending on the browser you have a set number of requests that can run in parallel. If you load a lot of images in your CSS it is possible to automatically inline these images as BASE64 strings to lower the number of requests required. This can be based on the size of the image. There is a balance of size of download and number of downloads that you have to figure out for your project, and Webpack makes that balance easy to adjust.
 
 ## Installing the url-loader
-`npm install url-loader --save-dev` will install the loader that can convert resolved paths as BASE64 strings. As mentioned in other sections of this cookbook Webpack will resolve "url()" statements in your CSS as any other require or import statements. This means that if we test on image file extensions for this loader we can run them through it.
+`npm install url-loader file-loader --save-dev` will install the loader that can convert resolved paths as BASE64 strings. As mentioned in other sections of this cookbook Webpack will resolve "url()" statements in your CSS as any other require or import statements. This means that if we test on image file extensions for this loader we can run them through it.
 
 ```javascript
 var path = require('path');


### PR DESCRIPTION
In addition to `url-loader`,  `file-loader` was required to process inline images in styles, updated the instructions to add file-loader 