### PR TITLE
sass-loader requires node-sass but none was installed

### DIFF
--- a/content/Loading-LESS-or-SASS.md
+++ b/content/Loading-LESS-or-SASS.md
@@ -2,7 +2,7 @@ If you want to use compiled CSS, there are two loaders available for you. The **
 
 ## Installing and configuring the loader
 
-`npm install less-loader` or `npm install sass-loader`.
+`npm install less-loader` or `npm install sass-loader node-sass`.
 
 **webpack.config.js**
 


### PR DESCRIPTION
….

From the sass-loader docs https://github.com/jtangelder/sass-loader
the instalation is `npm install sass-loader node-sass webpack --save-dev`

So I added the required `node-sass` to avoid wrong installations and errors.